### PR TITLE
allow to hide world in publish settings and small fixes to search page

### DIFF
--- a/public/adl/sandbox/views/publish.html
+++ b/public/adl/sandbox/views/publish.html
@@ -70,6 +70,7 @@ color: lightgray;
 					$('#chkAllowTools').prop('disabled', false);
 					$('#chkAllowAnonymous').prop('disabled', false);
 					$('#chkCreateAvatar').prop('disabled', false);
+					$('#chkHidden').prop('disabled', false);
 
 					
 
@@ -83,6 +84,8 @@ color: lightgray;
 						$('#chkSinglePlayer')[0].checked = true;
 					if(data.publishSettings.createAvatar)
 						$('#chkCreateAvatar')[0].checked = true;
+					if(data.publishSettings.hidden)
+						$('#chkHidden')[0].checked = true;
 					if(data.publishSettings.camera)
 					{
 						lastActiveCamera = data.publishSettings.camera;
@@ -130,6 +133,7 @@ color: lightgray;
 		$('#chkAllowTools').prop('disabled', true);
 		$('#chkAllowAnonymous').prop('disabled', true);
 		$('#chkCreateAvatar').prop('disabled', true);
+		$('#chkHidden').prop('disabled', true);
 
 		$('#chkSinglePlayer').click(
 		 function(e){
@@ -173,6 +177,7 @@ color: lightgray;
 			statedata.allowAnonymous = $('#chkAllowAnonymous')[0].checked;
 			statedata.createAvatar = $('#chkCreateAvatar')[0].checked;
 			statedata.allowTools = $('#chkAllowTools')[0].checked;
+			statedata.hidden = $('#chkHidden')[0].checked;
 			statedata.persistence = $('#chkPersistence')[0].checked;
 		
 		
@@ -227,6 +232,8 @@ color: lightgray;
 				<input type='checkbox' id='chkAllowAnonymous'  name='AllowAnonymous'></input><label for='AllowAnonymous'>Allow Anonymous Users</label>
 				<br/>
 				<input type='checkbox' id='chkCreateAvatar' name='CreateAvatar'></input><label for='CreateAvatar'>Create Avatar for Each User</label>
+				<br/>
+				<input type='checkbox' id='chkHidden' name='Hidden'></input><label for='Hidden'>Hidden world</label>
 				<br/><br/>
 				<label for='Camera'>Choose Camera</label>
 				<br/>

--- a/support/server/DAL.js
+++ b/support/server/DAL.js
@@ -493,6 +493,9 @@ function getInstance(id, cb)
             if (doc.publishSettings.allowTools === undefined)
                 doc.publishSettings.allowTools = true;
 
+            if (doc.publishSettings.hidden === undefined)
+                doc.publishSettings.hidden = false;
+
             if (doc.publishSettings.persistence === undefined)
                 doc.publishSettings.persistence = true;
         }

--- a/support/server/landingRoutes.js
+++ b/support/server/landingRoutes.js
@@ -513,7 +513,8 @@ exports.world = function(req, res, next) {
 function NotHidden(inst){
 
     if(inst.publishSettings !== undefined)
-        if(inst.publishSettings.hidden)
+       if(inst.publishSettings !== null) 
+            if(inst.publishSettings.hidden)
             return false
     return true
 };

--- a/support/server/landingRoutes.js
+++ b/support/server/landingRoutes.js
@@ -470,7 +470,7 @@ exports.world = function(req, res, next) {
                 res.redirect(global.appPath);
                 return;
             }
-            var instance = global.instances ? global.instances.get("/adl/sandbox" + "/" + req.params.page + "/") : false;
+            var instance = global.instances ? global.instances.get(worldID) : false;
             var anonymous = [];
             var users = [];
 
@@ -510,10 +510,17 @@ exports.world = function(req, res, next) {
     });
 };
 
+function NotHidden(inst){
+
+    if(inst.publishSettings !== undefined)
+        if(inst.publishSettings.hidden)
+            return false
+    return true
+};
+
 function ShowSearchPage(mode, req, res, next) {
     sessions.GetSessionData(req, function(sessionData) {
         function foundStates(allinstances) {
-
 
             var results = [];
 
@@ -534,7 +541,8 @@ function ShowSearchPage(mode, req, res, next) {
                     inst.id = i;
                     inst.shortid = i.substr("/adl/sandbox".length + 1, 16);
                     if (global.instances) {
-                        if (global.instances.get(i.replace(/_/g, "/")))
+                        if (global.instances.get(i))
+                            if (NotHidden(inst))
                             results.push(inst);
                     }
                 }
@@ -550,7 +558,8 @@ function ShowSearchPage(mode, req, res, next) {
                     inst.id = i;
                     inst.shortid = i.substr("/adl/sandbox".length + 1, 16);
                     if (inst.title.toLowerCase().indexOf(search) != -1 || inst.description.toLowerCase().indexOf(search) != -1 || inst.owner.toLowerCase().indexOf(search) != -1 || inst.shortid.toLowerCase().indexOf(search) != -1)
-                        results.push(inst);
+                        if (NotHidden(inst))
+                            results.push(inst);
                 }
                 results.sort(function(a, b) {
                     return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
@@ -570,6 +579,24 @@ function ShowSearchPage(mode, req, res, next) {
                     return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
                 });
             }
+
+
+            if (mode == 'hidden' && sessionData) {
+            if (sessionData.UID == 'admin') {
+                for (var i in allinstances) {
+                    var inst = allinstances[i];
+                    if (!inst) continue;
+                    inst.id = i;
+                    inst.shortid = i.substr("/adl/sandbox".length + 1, 16)
+                    if (NotHidden(inst) == false)
+                        results.push(inst);
+                }
+                results.sort(function(a, b) {
+                    return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
+                });
+            }
+            }
+
             if (mode == 'featured') {
                 for (var i in allinstances) {
                     var inst = allinstances[i];
@@ -577,7 +604,8 @@ function ShowSearchPage(mode, req, res, next) {
                     inst.id = i;
                     inst.shortid = i.substr("/adl/sandbox".length + 1, 16)
                     if (inst.featured)
-                        results.push(inst);
+                        if (NotHidden(inst))
+                            results.push(inst);
                 }
                 results.sort(function(a, b) {
                     return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
@@ -590,7 +618,8 @@ function ShowSearchPage(mode, req, res, next) {
                     if (!inst) continue;
                     inst.id = i;
                     inst.shortid = i.substr("/adl/sandbox".length + 1, 16)
-                    results.push(inst);
+                    if (NotHidden(inst))
+                        results.push(inst);
                 }
                 results.sort(function(a, b) {
                     return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
@@ -602,7 +631,8 @@ function ShowSearchPage(mode, req, res, next) {
                     if (!inst) continue;
                     inst.id = i;
                     inst.shortid = i.substr("/adl/sandbox".length + 1, 16)
-                    results.push(inst);
+                    if (NotHidden(inst))
+                        results.push(inst);
                 }
                 results.sort(function(a, b) {
                     return Date.parse(b.created || b.lastUpdate) - Date.parse(a.created || a.lastUpdate);
@@ -665,6 +695,8 @@ function ShowSearchPage(mode, req, res, next) {
             DAL.getStates(foundStates)
         if (mode == "my")
             DAL.searchStatesByUser(sessionData.UID, foundStates)
+        if (mode == "hidden")
+            DAL.getStates(foundStates)
         if (mode == "search")
             DAL.searchStates(search, foundStates)
     })
@@ -684,6 +716,9 @@ exports.allWorlds = function(req, res, next) {
 };
 exports.myWorlds = function(req, res, next) {
     ShowSearchPage('my', req, res, next);
+};
+exports.hidden = function(req, res, next) {
+    ShowSearchPage('hidden', req, res, next);
 };
 exports.featuredWorlds = function(req, res, next) {
     ShowSearchPage('featured', req, res, next);

--- a/support/server/sandbox.js
+++ b/support/server/sandbox.js
@@ -858,6 +858,7 @@ function startVWF() {
                 app.get("/adl/sandbox" + '/newWorlds', Landing.newWorlds);
                 app.get("/adl/sandbox" + '/allWorlds/:page([0-9]+)', Landing.allWorlds);
                 app.get("/adl/sandbox" + '/myWorlds/:page([0-9]+)', Landing.myWorlds);
+                app.get("/adl/sandbox" + '/hidden/:page([0-9]+)', Landing.hidden);
                 app.get("/adl/sandbox" + '/featuredWorlds/:page([0-9]+)', Landing.featuredWorlds);
                 app.get("/adl/sandbox" + '/activeWorlds/:page([0-9]+)', Landing.activeWorlds);
                 app.get("/adl/sandbox", Landing.generalHandler);

--- a/support/server/sandboxAPI.js
+++ b/support/server/sandboxAPI.js
@@ -880,6 +880,7 @@ function Publish(URL, SID, publishdata, response)
 			var allowAnonymous = publishdata.allowAnonymous;
 			var createAvatar = publishdata.createAvatar;
 			var allowTools = publishdata.allowTools;
+			var hidden = publishdata.hidden;
 			var persistence = publishdata.persistence;
 			publishSettings = {
 				singlePlayer: singlePlayer,
@@ -887,6 +888,7 @@ function Publish(URL, SID, publishdata, response)
 				allowAnonymous: allowAnonymous,
 				createAvatar: createAvatar,
 				allowTools: allowTools,
+				hidden: hidden,
 				persistence: persistence,
 			};
 		}


### PR DESCRIPTION
Allow a world to be hidden in a search results page. 'Hidden' property is available in world publish settings. Admin could query all hidden worlds using url /hidden/0